### PR TITLE
4-to-5 migration improvments

### DIFF
--- a/go-migrate/cli.go
+++ b/go-migrate/cli.go
@@ -24,6 +24,10 @@ func (f *Flags) Setup() {
 	flag.BoolVar(&f.NoRevert, "no-revert", false, "do not attempt to automatically revert on failure")
 }
 
+var SupportNoRevert = map[string]bool{
+	"4-to-5": true,
+}
+
 func (f *Flags) Parse() {
 	flag.Parse()
 }
@@ -52,10 +56,8 @@ func Run(m Migration) error {
 		}
 	}
 
-	if f.NoRevert {
-		if nr, ok := m.(SupportNoRevert); !ok || !nr.SupportNoRevert() {
-			return fmt.Errorf("migration %s does not support the '-no-revert' option", m.Versions())
-		}
+	if f.NoRevert && !SupportNoRevert[m.Versions()] {
+		return fmt.Errorf("migration %s does not support the '-no-revert' option", m.Versions())
 	}
 
 	if f.Revert {

--- a/go-migrate/cli.go
+++ b/go-migrate/cli.go
@@ -7,11 +7,12 @@ import (
 )
 
 type Flags struct {
-	Force   bool
-	Revert  bool
-	Path    string // file path to migrate for fs based migrations
-	Verbose bool
-	Help    bool
+	Force    bool
+	Revert   bool
+	Path     string // file path to migrate for fs based migrations
+	Verbose  bool
+	Help     bool
+	NoRevert bool
 }
 
 func (f *Flags) Setup() {
@@ -20,6 +21,7 @@ func (f *Flags) Setup() {
 	flag.BoolVar(&f.Verbose, "verbose", false, "enable verbose logging")
 	flag.BoolVar(&f.Help, "help", false, "display help message")
 	flag.StringVar(&f.Path, "path", "", "file path to migrate for fs based migrations (required)")
+	flag.BoolVar(&f.NoRevert, "no-revert", false, "do not attempt to automatically revert on failure")
 }
 
 func (f *Flags) Parse() {
@@ -43,10 +45,16 @@ func Run(m Migration) error {
 
 	if !m.Reversible() {
 		if f.Revert {
-			return fmt.Errorf("migration %d is irreversible", m.Versions())
+			return fmt.Errorf("migration %s is irreversible", m.Versions())
 		}
 		if !f.Force {
-			return fmt.Errorf("migration %d is irreversible (use -f to proceed)", m.Versions())
+			return fmt.Errorf("migration %s is irreversible (use -f to proceed)", m.Versions())
+		}
+	}
+
+	if f.NoRevert {
+		if nr, ok := m.(SupportNoRevert); !ok || !nr.SupportNoRevert() {
+			return fmt.Errorf("migration %s does not support the '-no-revert' option", m.Versions())
 		}
 	}
 

--- a/go-migrate/migrate.go
+++ b/go-migrate/migrate.go
@@ -29,6 +29,13 @@ type Migration interface {
 	Revert(Options) error
 }
 
+type SupportNoRevert interface {
+	Migration
+
+	// Supports the NoRevert option
+	SupportNoRevert() bool
+}
+
 func SplitVersion(s string) (from int, to int) {
 	_, err := fmt.Scanf(s, "%d-to-%d", &from, &to)
 	if err != nil {

--- a/go-migrate/migrate.go
+++ b/go-migrate/migrate.go
@@ -29,13 +29,6 @@ type Migration interface {
 	Revert(Options) error
 }
 
-type SupportNoRevert interface {
-	Migration
-
-	// Supports the NoRevert option
-	SupportNoRevert() bool
-}
-
 func SplitVersion(s string) (from int, to int) {
 	_, err := fmt.Scanf(s, "%d-to-%d", &from, &to)
 	if err != nil {

--- a/ipfs-4-to-5/migration/migration.go
+++ b/ipfs-4-to-5/migration/migration.go
@@ -25,10 +25,6 @@ func (m Migration) Reversible() bool {
 	return true
 }
 
-func (m Migration) SupportNoRevert() bool {
-	return true
-}
-
 func revertStep2(ffspath string) error {
 	if err := flatfs.DowngradeV1toV0(ffspath); err != nil {
 		return fmt.Errorf("reverting flatfsv1 upgrade: %s", err)

--- a/sharness/t0080-migration-3-to-4.sh
+++ b/sharness/t0080-migration-3-to-4.sh
@@ -105,6 +105,10 @@ test_expect_success "get pin lists" '
 
 test_kill_ipfs_daemon
 
+test_expect_success "'ipfs-3-to-4 -no-revert' fails" '
+	test_must_fail ipfs-3-to-4 -no-revert -path="$IPFS_PATH"
+'
+
 test_install_ipfs_nd "v0.4.3-dev"
 
 test_launch_ipfs_daemon

--- a/sharness/t0091-4-to-5-error-recovery.sh
+++ b/sharness/t0091-4-to-5-error-recovery.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+test_description="Test migration 4 to 5 woth -no-revert"
+
+. lib/test-lib.sh
+
+# setup vars for tests
+
+export IPFS_DIST_PATH="/ipfs/QmRgeXaMTu426NcVvTNywAR7HyFBFGhvRc9FuTtKx3Hfno"
+
+DEPTH=3
+NBDIR=3
+NBFILE=6
+PINTOTAL=20
+
+PINEACH=$(expr $PINTOTAL / 2)
+
+echo "DEPTH: $DEPTH"
+echo "NBDIR: $NBDIR"
+echo "NBFILE: $NBFILE"
+echo "PINTOTAL: $PINTOTAL"
+echo "PINEACH: $PINEACH"
+
+export GOPATH="$(pwd)/gopath"
+mkdir -p gopath/bin
+export PATH="../bin:$GOPATH/bin:$PATH"
+
+test_install_ipfs_nd "v0.4.4"
+
+test_init_ipfs_nd
+
+test_expect_success "make a couple files" '
+	rm -rf manyfiles &&
+	random-files -depth=$DEPTH -dirs=$NBDIR -files=$NBFILE manyfiles > filenames
+'
+
+test_expect_success "add a few files" '
+	ipfs add -r -q manyfiles | tee hashes
+'
+
+test_expect_success "get full ref list" '
+	ipfs refs local | sort > start_refs
+'
+test_expect_success "create a permission problem" '
+	RANDOM_DIR="`(cd "$IPFS_PATH"/blocks/ && ls -d CI??? | sort | head -3 | tail -1)`" &&
+	chmod 000 "$IPFS_PATH/blocks/$RANDOM_DIR"
+'
+
+test_expect_success "ipfs-4-to-5 -no-revert should fail" '
+	test_must_fail ipfs-4-to-5 -no-revert -path "$IPFS_PATH"
+'
+
+test_expect_success "ipfs-4-to-5 -no-revert leaves repo in inconsistent state" '
+	test -d "$IPFS_PATH"/blocks-v4 &&
+	test -d "$IPFS_PATH"/blocks-v5
+'
+
+test_expect_success "fix permission problem" '
+	chmod 700 "$IPFS_PATH/blocks-v4/$RANDOM_DIR"
+'
+
+test_expect_success "ipfs-4-to-5 -no-revert should be okay now" '
+	ipfs-4-to-5 -no-revert -path "$IPFS_PATH"
+'
+
+test_install_ipfs_nd "v0.4.5-pre2"
+
+test_expect_success "list all refs after migration" '
+	ipfs refs local | sort > after_refs
+'
+
+test_expect_success "refs look right" '
+	comm -23 start_refs after_refs > missing_refs &&
+	touch empty_refs_file &&
+	test_cmp missing_refs empty_refs_file
+'
+
+test_done


### PR DESCRIPTION
Try to recover from an interrupted migration in `ipfs-4-to-5` and add a `-no-revert` option to avoid automatically reverting in case of failure.

This doesn't cover all failure cases but covers the most common ones (mainly flatfs.Move being interrupted or failing for some reason).  For other failure cases it should be possible to manually fix up the repo and then rerunning `ipfs-4-to-5`.