### PR TITLE
fs-repo-migrations can now revert

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,6 +145,7 @@ func main() {
 	target := flag.Int("to", CurrentVersion, "specify version to upgrade to")
 	yes := flag.Bool("y", false, "answer yes to all prompts")
 	version := flag.Bool("v", false, "print highest repo version and exit")
+	revertOk := flag.Bool("revert-ok", false, "allow running migrations backward")
 
 	flag.Parse()
 
@@ -167,6 +168,11 @@ func main() {
 	vnum, err := GetVersion(ipfsdir)
 	if err != nil {
 		fmt.Println("ipfs migration: ", err)
+		os.Exit(1)
+	}
+
+	if vnum > *target && !*revertOk {
+		fmt.Println("ipfs migration: attempt to run backward migration\nTo allow, run this command again with --revert-ok")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -65,8 +65,8 @@ func GetIpfsDir() (string, error) {
 	return "", err
 }
 
-func runMigration(n int) error {
-	fmt.Printf("===> Running migration %d to %d...\n", n, n+1)
+func runMigration(from int, to int, backward bool) error {
+	fmt.Printf("===> Running migration %d to %d...\n", from, to)
 	path, err := GetIpfsDir()
 	if err != nil {
 		return err
@@ -76,18 +76,30 @@ func runMigration(n int) error {
 	opts.Path = path
 	opts.Verbose = true
 
-	err = migrations[n].Apply(opts)
-	if err != nil {
-		return fmt.Errorf("migration %d to %d failed: %s", n, n+1, err)
+	if to > from {
+		err = migrations[from].Apply(opts)
+	} else if to < from {
+		err = migrations[to].Revert(opts)
+	} else {
+		// catch this earlier. expected invariant violated.
+		err = fmt.Errorf("attempt to run migration to same version")
 	}
-	fmt.Printf("===> Migration %d to %d succeeded!\n", n, n+1)
+	if err != nil {
+		return fmt.Errorf("migration %d to %d failed: %s", from, to, err)
+	}
+	fmt.Printf("===> Migration %d to %d succeeded!\n", from, to)
 	return nil
 }
 
 func doMigrate(from, to int) error {
-	cur := from
-	for ; cur < to; cur++ {
-		err := runMigration(cur)
+	backward := from > to
+	step := 1
+	if backward {
+		step = -1
+	}
+
+	for cur := from; cur != to; cur += step {
+		err := runMigration(cur, cur + step, backward)
 		if err != nil {
 			return err
 		}
@@ -158,8 +170,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if vnum >= *target {
-		fmt.Println("ipfs migration: already at or above target version number")
+	if vnum == *target {
+		fmt.Println("ipfs migration: already at target version number")
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func GetIpfsDir() (string, error) {
 	return "", err
 }
 
-func runMigration(from int, to int, backward bool) error {
+func runMigration(from int, to int) error {
 	fmt.Printf("===> Running migration %d to %d...\n", from, to)
 	path, err := GetIpfsDir()
 	if err != nil {
@@ -92,14 +92,13 @@ func runMigration(from int, to int, backward bool) error {
 }
 
 func doMigrate(from, to int) error {
-	backward := from > to
 	step := 1
-	if backward {
+	if from > to {
 		step = -1
 	}
 
 	for cur := from; cur != to; cur += step {
-		err := runMigration(cur, cur + step, backward)
+		err := runMigration(cur, cur + step)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR enables fs-repo-migrations to run migrations backwards (reverts). I am not sure how it will play with go-ipfs or if it will cause invariants to be violated.

```
> cat ~/.ipfs/version
5

> ./fs-repo-migrations -to 4 -y
Found fs-repo version 5 at /Users/jbenet/.ipfs
===> Running migration 5 to 4...
reverting migration
Moving Keys...
90600 keys so far
Cleaning Up...
All Done.
lowered version number to 4
===> Migration 5 to 4 succeeded!

> cat ~/.ipfs/version
4

> ./fs-repo-migrations -to 5 -y
Found fs-repo version 4 at /Users/jbenet/.ipfs
===> Running migration 4 to 5...
applying 4-to-5 repo migration
locking repo at "/Users/jbenet/.ipfs"
  - verifying version is '4'
> Upgrading datastore format to have sharding specification file
> creating a new flatfs datastore with new format
> converting current flatfs datastore to new format
Moving Keys...
90610 keys so far
Cleaning Up...
All Done.
> moving new datastore into place
> moving transferred datastore back into place
updated version file
===> Migration 4 to 5 succeeded!

> cat ~/.ipfs/version
5
```