### PR TITLE
fix: handle /ipfs/ addrs when migrating bootstrappers

### DIFF
--- a/ipfs-9-to-10/migration/config_conv.go
+++ b/ipfs-9-to-10/migration/config_conv.go
@@ -130,6 +130,12 @@ func ver9to10Bootstrap(bootstrap []string) []string {
 	hasNew := false
 	res := make([]string, 0, len(bootstrap)+1)
 	for _, addr := range bootstrap {
+		// Upgrade /ipfs & /p2p. This should have happened in migration
+		// 7-to-8, but that migration wouldn't run at all if we already
+		// had the new bootstrappers.
+		addr = strings.Replace(addr, "/ipfs/Qm", "/p2p/Qm", -1)
+		addr = strings.Replace(addr, "/ipfs/1", "/p2p/1", -1)
+
 		res = append(res, addr)
 		if addr == ip4BootstrapAddr {
 			hasOld = true

--- a/sharness/t0130-migration-9-to-10.sh
+++ b/sharness/t0130-migration-9-to-10.sh
@@ -85,6 +85,26 @@ test_expect_success "re-run migration 9 to 10" '
 # Shouldn't do anything this time, now that we have an address.
 check_results
 
+# Should also work with /ipfs/ addresses
+test_expect_success "add bootstrap addresses" '
+  test_config_set --json Bootstrap "[
+  \"/dnsaddr/bootstrap.libp2p.io/ipfs/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb\",
+  \"/dnsaddr/bootstrap.libp2p.io/ipfs/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt\",
+  \"/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ\",
+  \"/dnsaddr/bootstrap.libp2p.io/ipfs/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN\",
+  \"/dnsaddr/bootstrap.libp2p.io/ipfs/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa\"
+]"
+'
+
+test_expect_success "re-run migration 9 to 10" '
+  echo 9 > "$IPFS_PATH/version" &&
+  echo $IPFS_PATH &&
+  ipfs-9-to-10 -verbose -path="$IPFS_PATH"
+'
+
+# Shouldn't do anything this time, now that we have an address.
+check_results
+
 test_expect_success "revert migration 10 to 9 succeeds" '
   ipfs-9-to-10 -revert -verbose -path="$IPFS_PATH"
 '


### PR DESCRIPTION
In 7-to-8, we skipped the bootstrapper migration when the peer already had all the new bootstrappers. Unfortunately, this meant we didn't migrate `/ipfs/` addresses to `/p2p/` addresses, which prevented the 9-to-10 migration from correctly migrating the bootstrap address.