### PR TITLE
resolve homedir

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,11 @@ var migrations = []gomigrate.Migration{
 func GetIpfsDir() (string, error) {
 	ipfspath := os.Getenv("IPFS_PATH")
 	if ipfspath != "" {
-		return ipfspath, nil
+		expandedPath, err := homedir.Expand(ipfspath)
+		if err != nil {
+			return "", err
+		}
+		return expandedPath, nil
 	}
 
 	home, err := homedir.Dir()


### PR DESCRIPTION
While go-ipfs will resolve `~/myipfspath` into `userHomeDir/myipfspath` fs-repo-migrations would not. This PR adds resolving `~` into the users' home directory. 

Review by commit, since this PR includes some overdue `go fmt` changes as well.