### PR TITLE
Do not ignore arguments

### DIFF
--- a/fs-repo-migrations/main.go
+++ b/fs-repo-migrations/main.go
@@ -46,6 +46,12 @@ func main() {
 	yes := flag.Bool("y", false, "answer yes to all prompts")
 	flag.Parse()
 
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "unrecognized arguments")
+		flag.Usage()
+		os.Exit(1)
+	}
+
 	fetcher := createFetcher(*distPath)
 
 	var (


### PR DESCRIPTION
This fixes issue #11

After fix:
```
> fs-repo-migrations/fs-repo-migrations sdff sdfsf sdfsdf
unrecognized arguments
Usage of fs-repo-migrations/fs-repo-migrations:
  -distpath string
        specify the distributions build to use
  -revert-ok
        allow running migrations backward
  -to string
        repo version to upgrade to, or "latest" for latest repo version (default "latest")
  -v    print latest migration available and exit
  -y    answer yes to all prompts
```