### PR TITLE
11-to-12: Re-work logic to use the backup file for both migrate and revert

### DIFF
--- a/fs-repo-11-to-12/go.mod
+++ b/fs-repo-11-to-12/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ipfs/fs-repo-migrations/tools v0.0.0-20211209222258-754a2dcb82ea
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.5
-	github.com/ipfs/go-ds-badger v0.2.7-0.20211210151007-a2805355dcf5 // indirect
+	github.com/ipfs/go-ds-badger v0.2.7-0.20220117180822-159330558612 // indirect
 	github.com/ipfs/go-filestore v1.0.0
 	github.com/ipfs/go-ipfs v0.8.0
 	github.com/ipfs/go-ipfs-ds-help v1.0.0

--- a/fs-repo-11-to-12/go.sum
+++ b/fs-repo-11-to-12/go.sum
@@ -295,8 +295,8 @@ github.com/ipfs/go-ds-badger v0.0.7/go.mod h1:qt0/fWzZDoPW6jpQeqUjR5kBfhDNB65jd9
 github.com/ipfs/go-ds-badger v0.2.1/go.mod h1:Tx7l3aTph3FMFrRS838dcSJh+jjA7cX9DrGVwx/NOwE=
 github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
 github.com/ipfs/go-ds-badger v0.2.6/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
-github.com/ipfs/go-ds-badger v0.2.7-0.20211210151007-a2805355dcf5 h1:ovdpQk2ZVK6eQLzMCZy1z2tJae7yvE8xaPUw4Pr1RqI=
-github.com/ipfs/go-ds-badger v0.2.7-0.20211210151007-a2805355dcf5/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
+github.com/ipfs/go-ds-badger v0.2.7-0.20220117180822-159330558612 h1:Uvp2/ZNlR3YmH04XJGv4YsPabhPzRPyeroLltVKBSr8=
+github.com/ipfs/go-ds-badger v0.2.7-0.20220117180822-159330558612/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
 github.com/ipfs/go-ds-flatfs v0.4.5 h1:4QceuKEbH+HVZ2ZommstJMi3o3II+dWS3IhLaD7IGHs=
 github.com/ipfs/go-ds-flatfs v0.4.5/go.mod h1:e4TesLyZoA8k1gV/yCuBTnt2PJtypn4XUlB5n8KQMZY=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=

--- a/fs-repo-11-to-12/migration/swapper.go
+++ b/fs-repo-11-to-12/migration/swapper.go
@@ -143,8 +143,11 @@ func (cswap *CidSwapper) swapWorker(dryRun bool, resultsCh <-chan query.Result) 
 		c, err := dsKeyToCid(ds.NewKey(oldKey.BaseNamespace())) // remove prefix
 		if err != nil {
 			// complain if we find anything that is not a CID but
-			// leave it as it is.
-			log.Log("could not parse %s as a Cid", oldKey)
+			// leave it as it is.  This can potentially be raw
+			// multihashes that are not CIDv0s (i.e. using
+			// anything other than sha256). They may come from a
+			// previous migration.
+			log.VLog("could not parse %s as a Cid", oldKey)
 			continue
 		}
 		if c.Version() == 0 { // CidV0 are multihashes, leave them.

--- a/fs-repo-11-to-12/migration/swapper.go
+++ b/fs-repo-11-to-12/migration/swapper.go
@@ -2,6 +2,8 @@ package mg11
 
 import (
 	"errors"
+	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 
@@ -18,6 +20,32 @@ var SyncSize uint64 = 20 * 1024 * 1024 // 20MiB
 // NWorkers sets the number of swapping threads to run when applying a
 // migration.
 var NWorkers int = 4
+
+func init() {
+	workerEnvVar := "IPFS_FS_MIGRATION_11_TO_12_NWORKERS"
+	syncSizeEnvVar := "IPFS_FS_MIGRATION_11_TO_12_SYNC_SIZE"
+	if nworkersStr, nworkerInEnv := os.LookupEnv(workerEnvVar); nworkerInEnv {
+		nworkers, err := strconv.Atoi(nworkersStr)
+		if err != nil {
+			panic(err)
+		}
+		if nworkers < 1 {
+			panic("number of workers must be at least 1")
+		}
+		NWorkers = nworkers
+	}
+
+	if syncSizeStr, syncSizeInEnv := os.LookupEnv(syncSizeEnvVar); syncSizeInEnv {
+		syncSize, err := strconv.ParseUint(syncSizeStr, 10, 64)
+		if err != nil {
+			panic(err)
+		}
+		if syncSize < 1 {
+			panic("sync size bytes must be at least 1")
+		}
+		SyncSize = syncSize
+	}
+}
 
 // Swap holds the datastore keys for the original CID and for the
 // destination Multihash.

--- a/fs-repo-11-to-12/migration/swapper.go
+++ b/fs-repo-11-to-12/migration/swapper.go
@@ -15,11 +15,11 @@ import (
 )
 
 // SyncSize specifies how much we batch data before committing and syncing.
-var SyncSize uint64 = 20 * 1024 * 1024 // 20MiB
+var SyncSize uint64 = 100 * 1024 * 1024 // 100MiB
 
 // NWorkers sets the number of swapping threads to run when applying a
 // migration.
-var NWorkers int = 4
+var NWorkers int = 1
 
 func init() {
 	workerEnvVar := "IPFS_FS_MIGRATION_11_TO_12_NWORKERS"

--- a/fs-repo-11-to-12/migration/swapper.go
+++ b/fs-repo-11-to-12/migration/swapper.go
@@ -23,7 +23,7 @@ var NWorkers int = 4
 
 func init() {
 	workerEnvVar := "IPFS_FS_MIGRATION_11_TO_12_NWORKERS"
-	syncSizeEnvVar := "IPFS_FS_MIGRATION_11_TO_12_SYNC_SIZE"
+	syncSizeEnvVar := "IPFS_FS_MIGRATION_11_TO_12_SYNC_SIZE_BYTES"
 	if nworkersStr, nworkerInEnv := os.LookupEnv(workerEnvVar); nworkerInEnv {
 		nworkers, err := strconv.Atoi(nworkersStr)
 		if err != nil {

--- a/fs-repo-11-to-12/migration/swapper.go
+++ b/fs-repo-11-to-12/migration/swapper.go
@@ -62,13 +62,11 @@ type CidSwapper struct {
 	SwapCh chan Swap   // a channel that gets notified for every swap
 }
 
-// Run lists all the keys in the datastore and triggers a swap operation for
-// those corresponding to CIDv1s (replacing them by their raw multihash).
-// When dryRun is true, it will not perform any changes, but notify SwapCh
-// as if it would.
+// Prepare performs a dry run without copying anything but notifying SwapCh
+// as it runs.
 //
-// Run returns the total number of keys swapped.
-func (cswap *CidSwapper) Run(dryRun bool) (uint64, error) {
+// Retruns the total number of keys swapped.
+func (cswap *CidSwapper) Prepare() (uint64, error) {
 	// Query all keys. We will loop all keys
 	// and swap those that can be parsed as CIDv1.
 	queryAll := query.Query{
@@ -83,7 +81,18 @@ func (cswap *CidSwapper) Run(dryRun bool) (uint64, error) {
 	defer results.Close()
 	resultsCh := results.Next()
 	swapWorkerFunc := func() (uint64, uint64) {
-		return cswap.swapWorker(dryRun, resultsCh)
+		return cswap.prepareWorker(resultsCh) // dry-run=true
+	}
+	return cswap.runWorkers(NWorkers, swapWorkerFunc)
+}
+
+// Run performs a migration reading the Swaps that need to be performed
+// from the given Swap channel. The swaps can be obtained with Prepare().
+//
+// Run returns the total number of keys swapped.
+func (cswap *CidSwapper) Run(swapCh <-chan Swap) (uint64, error) {
+	swapWorkerFunc := func() (uint64, uint64) {
+		return cswap.swapWorker(swapCh, false) // reverting=false
 	}
 	return cswap.runWorkers(NWorkers, swapWorkerFunc)
 }
@@ -93,7 +102,7 @@ func (cswap *CidSwapper) Run(dryRun bool) (uint64, error) {
 // swap operations performed.
 func (cswap *CidSwapper) Revert(unswapCh <-chan Swap) (uint64, error) {
 	swapWorkerFunc := func() (uint64, uint64) {
-		return cswap.unswapWorker(unswapCh)
+		return cswap.swapWorker(unswapCh, true) // reverting=true
 	}
 	return cswap.runWorkers(NWorkers, swapWorkerFunc)
 }
@@ -120,10 +129,10 @@ func (cswap *CidSwapper) runWorkers(nWorkers int, f func() (uint64, uint64)) (ui
 	return total, nil
 }
 
-// swapWorkers reads query results from a channel and renames CIDv1 keys to
+// prepareWorker reads query results from a channel and renames CIDv1 keys to
 // raw multihashes by reading the blocks and storing them with the new
 // key. Returns the number of keys swapped and the number of errors.
-func (cswap *CidSwapper) swapWorker(dryRun bool, resultsCh <-chan query.Result) (uint64, uint64) {
+func (cswap *CidSwapper) prepareWorker(resultsCh <-chan query.Result) (uint64, uint64) {
 	var errored uint64
 
 	sw := &swapWorker{
@@ -142,9 +151,9 @@ func (cswap *CidSwapper) swapWorker(dryRun bool, resultsCh <-chan query.Result) 
 		oldKey := ds.NewKey(res.Key)
 		c, err := dsKeyToCid(ds.NewKey(oldKey.BaseNamespace())) // remove prefix
 		if err != nil {
-			// complain if we find anything that is not a CID but
-			// leave it as it is.  This can potentially be raw
-			// multihashes that are not CIDv0s (i.e. using
+			// This means we have found something that is not a
+			// CID. We leave it as it is. This can potentially be
+			// raw multihashes that are not CIDv0s (i.e. using
 			// anything other than sha256). They may come from a
 			// previous migration.
 			log.VLog("could not parse %s as a Cid", oldKey)
@@ -159,34 +168,9 @@ func (cswap *CidSwapper) swapWorker(dryRun bool, resultsCh <-chan query.Result) 
 		// /path/to/old/<cid> -> /path/to/old/<multihash>
 		newKey := oldKey.Parent().Child(dshelp.MultihashToDsKey(mh))
 
-		if dryRun {
-			sw.swapped++ // otherwise this is done in sw.swap
-		} else {
-			// delete the old keys
-			err = sw.swap(oldKey, newKey, false)
-			if err != nil {
-				log.Error("swapping %s for %s: %s", oldKey, newKey, err)
-				errored++
-				continue
-			}
-		}
-
+		sw.swapped++
 		if cswap.SwapCh != nil {
 			cswap.SwapCh <- Swap{Old: oldKey, New: newKey}
-		}
-	}
-
-	if !dryRun {
-		// final sync
-		err := sw.syncAndDelete()
-		if err != nil {
-			log.Error("error performing last sync: %s", err)
-			errored++
-		}
-		err = sw.sync() // sync deleted items
-		if err != nil {
-			log.Error("error performing last sync for deletions: %s", err)
-			errored++
 		}
 	}
 
@@ -196,7 +180,7 @@ func (cswap *CidSwapper) swapWorker(dryRun bool, resultsCh <-chan query.Result) 
 // unswap worker takes notifications from unswapCh (as they would be sent by
 // the swapWorker) and undoes them. It ignores NotFound errors so that reverts
 // can succeed even if they failed half-way.
-func (cswap *CidSwapper) unswapWorker(unswapCh <-chan Swap) (uint64, uint64) {
+func (cswap *CidSwapper) swapWorker(swapCh <-chan Swap, reverting bool) (uint64, uint64) {
 	var errored uint64
 
 	swker := &swapWorker{
@@ -205,23 +189,26 @@ func (cswap *CidSwapper) unswapWorker(unswapCh <-chan Swap) (uint64, uint64) {
 	}
 
 	// Process keys from the results channel
-	for sw := range unswapCh {
-		// During revert, we always keep the old keys.  This addresses
-		// corner cases with keys that were referenced with both CIDv1
-		// and CIDv0 and with pins added post migration.
-		err := swker.swap(sw.New, sw.Old, true)
+	for sw := range swapCh {
+		if reverting {
+			old := sw.Old
+			sw.Old = sw.New
+			sw.New = old
+		}
+		err := swker.swap(sw.Old, sw.New, reverting)
 
-		// Did the user GC a migrated block?
+		// The datastore does not have the block we are planning to
+		// migrate.
 		if err == ds.ErrNotFound {
-			log.Error("could not revert %s->%s. Could not find %s. Was it GC'ed? This error is not fatal", sw.Old, sw.New, sw.New)
+			log.Error("could not swap %s->%s. Could not find %s even though it was in the backup file. Skipping.", sw.Old, sw.New, sw.Old)
 			continue
 		} else if err != nil {
-			log.Error("swapping %s for %s: %s", sw.New, sw.Old, err)
+			log.Error("swapping %s->%s: %s", sw.Old, sw.New, err)
 			errored++
 			continue
 		}
 		if cswap.SwapCh != nil {
-			cswap.SwapCh <- Swap{Old: sw.New, New: sw.Old}
+			cswap.SwapCh <- Swap{Old: sw.Old, New: sw.New}
 		}
 	}
 

--- a/fs-repo-11-to-12/vendor/github.com/ipfs/go-ds-badger/datastore.go
+++ b/fs-repo-11-to-12/vendor/github.com/ipfs/go-ds-badger/datastore.go
@@ -87,7 +87,7 @@ var DefaultOptions Options
 
 func init() {
 	DefaultOptions = Options{
-		GcDiscardRatio: 0.2,
+		GcDiscardRatio: 0.5,
 		GcInterval:     2 * time.Minute,
 		GcSleep:        10 * time.Second,
 		Options:        badger.LSMOnlyOptions(""),

--- a/fs-repo-11-to-12/vendor/modules.txt
+++ b/fs-repo-11-to-12/vendor/modules.txt
@@ -123,7 +123,7 @@ github.com/ipfs/go-datastore/mount
 github.com/ipfs/go-datastore/namespace
 github.com/ipfs/go-datastore/query
 github.com/ipfs/go-datastore/sync
-# github.com/ipfs/go-ds-badger v0.2.7-0.20211210151007-a2805355dcf5
+# github.com/ipfs/go-ds-badger v0.2.7-0.20220117180822-159330558612
 ## explicit
 github.com/ipfs/go-ds-badger
 # github.com/ipfs/go-ds-flatfs v0.4.5

--- a/sharness/t0030-simple-migration.sh
+++ b/sharness/t0030-simple-migration.sh
@@ -4,6 +4,8 @@ test_description="Simple fs-repo-migrations tests"
 
 . lib/test-lib.sh
 
+latestRepoVersion="12"
+
 test_expect_success "fs-repo-migrations binary is here" '
 	test -f "$LOCAL_FS_REPO_MIG"
 '
@@ -13,7 +15,7 @@ test_expect_success "'fs-repo-migrations -v' works" '
 '
 
 test_expect_success "'fs-repo-migrations -v' output looks good" '
-	echo "11" >expected &&
+	echo "$latestRepoVersion" >expected &&
 	test_cmp expected actual
 '
 
@@ -30,7 +32,7 @@ test_expect_success "'fs-repo-migrations -v' works" '
 '
 
 test_expect_success "'fs-repo-migrations -v' output looks good" '
-	echo "11" >expected &&
+	echo "$latestRepoVersion" >expected &&
 	test_cmp expected actual
 '
 


### PR DESCRIPTION
Before: we Query all keys and write a backup file. Then Query all keys and
    perform the swaps. This may cause that our query keeps getting results for all
    the keys that we are writing while we run it.

After: we perform a Prepare() step where we query all the keys and write the
    backup file. Then we read the backup file to perform the swaps without making
    another query.

This also means that the migration (swapper.Run()) becomes very similar to the
    revert (swapper.Revert()), since both read from the backup file. We are thus
    able to refactor code and re-use logic better.

We have also tuned down the noise when encountering multihashes that are not
    CIDv0s.