### PR TITLE
feat: fs-repo-11-to-12 special flatfs handling

### DIFF
--- a/fs-repo-11-to-12/go.mod
+++ b/fs-repo-11-to-12/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.5
 	github.com/ipfs/go-ds-badger v0.2.7-0.20220117180822-159330558612 // indirect
+	github.com/ipfs/go-ds-flatfs v0.4.5
 	github.com/ipfs/go-filestore v1.0.0
 	github.com/ipfs/go-ipfs v0.8.0
 	github.com/ipfs/go-ipfs-ds-help v1.0.0

--- a/fs-repo-11-to-12/migration/migration.go
+++ b/fs-repo-11-to-12/migration/migration.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 
 	log "github.com/ipfs/fs-repo-migrations/tools/stump"
 
@@ -42,8 +41,7 @@ var migrationPrefixes = []ds.Key{
 
 // Migration implements the migration described above.
 type Migration struct {
-	loadPluginsOnce sync.Once
-	dstore          ds.Batching
+	dstore ds.Batching
 }
 
 // Versions returns the current version string for this migration.

--- a/fs-repo-11-to-12/migration/migration_test.go
+++ b/fs-repo-11-to-12/migration/migration_test.go
@@ -17,6 +17,24 @@ const (
 	workingRepo = "repotest_copy"
 )
 
+func TestGenericMigration(t *testing.T) {
+	origSetting := EnableFlatFSFastPath
+	defer func() {
+		EnableFlatFSFastPath = origSetting
+	}()
+	EnableFlatFSFastPath = false
+	testMigrationBase(t)
+}
+
+func TestFlatFSMigration(t *testing.T) {
+	origSetting := EnableFlatFSFastPath
+	defer func() {
+		EnableFlatFSFastPath = origSetting
+	}()
+	EnableFlatFSFastPath = true
+	testMigrationBase(t)
+}
+
 // TestMigration works on an IPFS repository as created by running steps.sh
 // with ipfs v0.8.0 on using the $repotest folder:
 //
@@ -28,7 +46,7 @@ const (
 // added bafybeie4pduk2uwvr5dq36wnbhxspgox7dtqo3fprri4r2wpa7vrej5jqq b
 // added Qmesmmf1EEG1orJb6XdK6DabxexsseJnCfw8pqWgonbkoj c/file3
 // added QmT3zhz9ZZjEpbzWib95EQ5ESUQs4YasrMQwPScpNGLEXZ c
-func TestMigration(t *testing.T) {
+func testMigrationBase(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/fs-repo-11-to-12/migration/migration_test.go
+++ b/fs-repo-11-to-12/migration/migration_test.go
@@ -194,6 +194,7 @@ func testMigrationBase(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer m.dstore.Close()
 
 	// Check that the CIDv1s that we explicitally pinned or
 	// added to MFS are now retrievable as CIDv1-addressed nodes.

--- a/fs-repo-11-to-12/migration/swapper.go
+++ b/fs-repo-11-to-12/migration/swapper.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	log "github.com/ipfs/fs-repo-migrations/tools/stump"
 	cid "github.com/ipfs/go-cid"
@@ -257,7 +258,7 @@ func (cswap *CidSwapper) swapWorkerFlatFS(fsdsPath string, fsdsShard *flatfs.Sha
 
 		const swapLogThreshold = 10000
 		if swapped%swapLogThreshold == 0 {
-			log.Log("Migration worker has moved %d flatfs files", swapLogThreshold)
+			log.Log("%v: Migration worker has moved %d flatfs files and %d in total", time.Now(), swapLogThreshold, swapped)
 		}
 
 		if cswap.SwapCh != nil {
@@ -404,7 +405,7 @@ func (sw *swapWorker) syncAndDelete() error {
 }
 
 func (sw *swapWorker) sync() error {
-	log.Log("Migration worker syncing after %d objects migrated", sw.swapped)
+	log.Log("%v: Migration worker syncing after %d objects migrated", time.Now(), sw.swapped)
 	err := sw.store.Sync(sw.syncPrefix)
 	if err != nil {
 		return err

--- a/fs-repo-11-to-12/migration/swapper.go
+++ b/fs-repo-11-to-12/migration/swapper.go
@@ -428,7 +428,7 @@ func (sw *swapWorker) syncAndDelete() error {
 }
 
 func (sw *swapWorker) sync() error {
-	log.Log("%v: Migration worker syncing after %d objects migrated", time.Now(), sw.swapped)
+	log.Log("%v: Generic migration worker syncing after %d objects migrated", time.Now(), sw.swapped)
 	err := sw.store.Sync(sw.syncPrefix)
 	if err != nil {
 		return err

--- a/fs-repo-11-to-12/vendor/modules.txt
+++ b/fs-repo-11-to-12/vendor/modules.txt
@@ -127,6 +127,7 @@ github.com/ipfs/go-datastore/sync
 ## explicit
 github.com/ipfs/go-ds-badger
 # github.com/ipfs/go-ds-flatfs v0.4.5
+## explicit
 github.com/ipfs/go-ds-flatfs
 # github.com/ipfs/go-ds-leveldb v0.4.2
 github.com/ipfs/go-ds-leveldb


### PR DESCRIPTION
Trying to add some special casing fast-path code for flatfs.

Some things that are currently missing that may be problematic are:
- We're not using the datastore which means things like disk usage could technically end up out of sync, doesn't seem relevant though since we're not adding or removing data
- Reversions do not leave behind data copies (e.g. a CIDv0 and a CIDv1) which effects both the disk usage and more importantly the discoverability of data. Good news here is that we could use the slow code path for reversion and things should be fine (first let's see if CI catches the bug)
   - CI did catch the bug 🎉, and using the slow path for the reversion seems fine. I hope/suspect reversion of this migration will be very uncommon anyway