### PR TITLE
fix build on go 1.18: panic: qtls.ClientHelloInfo doesn't match

### DIFF
--- a/fs-repo-10-to-11/vendor/github.com/marten-seemann/qtls-go1-15/common.go
+++ b/fs-repo-10-to-11/vendor/github.com/marten-seemann/qtls-go1-15/common.go
@@ -7,6 +7,7 @@ package qtls
 import (
 	"bytes"
 	"container/list"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -349,6 +350,7 @@ type clientSessionState struct {
 // goroutines. Up to TLS 1.2, only ticket-based resumption is supported, not
 // SessionID-based resumption. In TLS 1.3 they were merged into PSK modes, which
 // are supported via this interface.
+//
 //go:generate sh -c "mockgen -package qtls -destination mock_client_session_cache_test.go github.com/marten-seemann/qtls-go1-15 ClientSessionCache"
 type ClientSessionCache = tls.ClientSessionCache
 
@@ -430,6 +432,10 @@ type clientHelloInfo struct {
 	// config is embedded by the GetCertificate or GetConfigForClient caller,
 	// for use with SupportsCertificate.
 	config *Config
+
+	// NOTE this field was added in go 1.17
+	// ctx is the context of the handshake that is in progress.
+	ctx context.Context
 }
 
 // CertificateRequestInfo contains information from a server's

--- a/fs-repo-11-to-12/vendor/github.com/marten-seemann/qtls-go1-15/common.go
+++ b/fs-repo-11-to-12/vendor/github.com/marten-seemann/qtls-go1-15/common.go
@@ -7,6 +7,7 @@ package qtls
 import (
 	"bytes"
 	"container/list"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -349,6 +350,7 @@ type clientSessionState struct {
 // goroutines. Up to TLS 1.2, only ticket-based resumption is supported, not
 // SessionID-based resumption. In TLS 1.3 they were merged into PSK modes, which
 // are supported via this interface.
+//
 //go:generate sh -c "mockgen -package qtls -destination mock_client_session_cache_test.go github.com/marten-seemann/qtls-go1-15 ClientSessionCache"
 type ClientSessionCache = tls.ClientSessionCache
 
@@ -430,6 +432,10 @@ type clientHelloInfo struct {
 	// config is embedded by the GetCertificate or GetConfigForClient caller,
 	// for use with SupportsCertificate.
 	config *Config
+
+	// NOTE this field was added in go 1.17
+	// ctx is the context of the handshake that is in progress.
+	ctx context.Context
 }
 
 // CertificateRequestInfo contains information from a server's


### PR DESCRIPTION
fix #156 
fix #157
fix #122

this (patching `vendor/`) is the simple way
and it works = both forward and reverse migrations finish without error
currently, migrations work from version 7 to 12

<details>

```sh
# warning: revert may cause data loss

path=/home/user/.ipfs

for a in $(seq 11 -1 7); do
  echo a=$a
  ./fs-repo-$a-*/fs-repo-* -path=$path -verbose=true -revert
  sleep 2 # workaround. fixme: migration should be sync
done

for a in $(seq 7 11); do
  echo a=$a
  ./fs-repo-$a-*/fs-repo-* -path=$path -verbose=true
  sleep 2 # workaround. fixme: migration should be sync
done
```

```
a=11
reverting 11-to-12 repo migration
locking repo at "/home/user/.ipfs"
  - verifying version is '12'
  - starting raw multihash to CIDv1 block migration
  - loading repo configurations
  - backup file will be read from /home/user/.ipfs/11-to-12-cids.txt
MFS Root: QmeY5vvgBJED4GsiHe35ubCmeGwiRFkA92gFaH6EEunxzg
2023-01-11 20:31:57.92946784 +0100 CET m=+12.757777763: Generic migration worker syncing after 839 objects migrated
2023-01-11 20:31:57.931535458 +0100 CET m=+12.759845342: Generic migration worker syncing after 839 objects migrated
839 multihashes swapped to CidV1s
reverted version file to version 11
a=10
reverting migration
opening datastore at "/home/user/.ipfs"
reverting pinning to use ipld storage
converted 22 pins from datastore to ipld storage
updated version file
a=9
reverting migration
lowered version number to 9
a=8
reverting migration
Renaming key's filename:  key_gezeim2ln5xvorstmvfvcr3ynzzhqrcljq4gqqlpljifqwtoojjw26tkpbghsqlfgzivordvonbuetkbjbqq
updated version file
a=7
reverting migration
lowered version number to 7
```

```
a=7
applying 7-to-8 repo migration
locking repo at "/home/user/.ipfs"
  - verifying version is '7'
> Upgrading config to new format
updated version file
Migration 7 to 8 succeeded
a=8
applying 8-to-9 repo migration
Renaming key's filename:  12D3KooWFSeKQGxnrxDKL8hAoZPXZnrSmzjxLyAe6QWDusCBMAHa
updated version file
Migration 8 to 9 succeeded
a=9
applying 9-to-10 repo migration
locking repo at "/home/user/.ipfs"
  - verifying version is '9'
> Upgrading config to new format
updated version file
Migration 9 to 10 succeeded
a=10
applying 10-to-11 repo migration
opening datastore at "/home/user/.ipfs"
upgrading pinning to use datastore
converted 22 pins from ipld storage into datastore
updated version file
Migration 10 to 11 succeeded
a=11
applying 11-to-12 repo migration
locking repo at "/home/user/.ipfs"
  - verifying version is '11'
  - loading repo configurations
  - starting CIDv1 to raw multihash block migration
  - backup file will be written to /home/user/.ipfs/11-to-12-cids.txt
  - Adding keys in prefix /blocks to backup file
could not parse /blocks/CEKKA3LXSBZOAHTTLJKUCLOGE2IABGZA5B7Q as a Cid
could not parse /blocks/DMQD5OBY4XKNEVVELXQVQTATPG3SYQJHFF4ZZ4XDZ6TULT345YVWRMI as a Cid
could not parse /blocks/CEKNYI7757GS72XPQA3P3JC6SSNP3BVK4XLQ as a Cid
could not parse /blocks/CEKFAJPXNH2ASKNWXQ27ILO6QRLBH23OWZPQ as a Cid
458 CIDv1 keys added to backup file for /blocks
  - Adding keys in prefix /filestore to backup file
0 CIDv1 keys added to backup file for /filestore
  - backup file will be read from /home/user/.ipfs/11-to-12-cids.txt
2023-01-11 20:32:44.974778209 +0100 CET m=+0.533970302: Migration worker has moved 458 flatfs files and 458 in total
2023-01-11 20:32:44.974941058 +0100 CET m=+0.534133115: Generic migration worker syncing after 0 objects migrated
2023-01-11 20:32:44.974997261 +0100 CET m=+0.534189293: Generic migration worker syncing after 0 objects migrated
458 CidV1s swapped to multihashes
updated version file
```

</details>



7-to-6 fails


```sh
a=6
./fs-repo-$a-*/fs-repo-* -path=$path -verbose=true -revert
# error: expected ed25519 data size to be 96
```

https://github.com/ipfs/fs-repo-migrations/blob/6c9f7fc4268bcff26578a5367038376549bbbcb3/fs-repo-6-to-7/gx/ipfs/QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo/go-libp2p-crypto/ed25519.go#L122

> this (patching `vendor/`) is the simple way

i also tried the hard way, trying to update the `quic-go` dependency, but failed

<details>


```sh
cd fs-repo-migrations
cd fs-repo-11-to-12

go mod graph | grep github.com/lucas-clemente/quic-go@v0.19.3
# github.com/ipfs/go-ipfs@v0.8.0 github.com/lucas-clemente/quic-go@v0.19.3
# github.com/libp2p/go-libp2p-quic-transport@v0.10.0 github.com/lucas-clemente/quic-go@v0.19.3

# update to quic-go@v0.20.0
go mod graph | grep github.com/lucas-clemente/quic-go
# v0.19.3
go mod edit -replace github.com/lucas-clemente/quic-go=github.com/lucas-clemente/quic-go@v0.20.0
go get github.com/lucas-clemente/quic-go@v0.20.0
go mod vendor
# error
# github.com/libp2p/go-libp2p-quic-transport imports
# github.com/lucas-clemente/quic-go/metrics: no required module provides package github.com/lucas-clemente/quic-go/metrics

# update to go-libp2p-quic-transport@v0.11.0
go mod graph | grep github.com/libp2p/go-libp2p-quic-transport
# v0.10.0
go mod edit -replace github.com/libp2p/go-libp2p-quic-transport=github.com/libp2p/go-libp2p-quic-transport@v0.11.0
go get github.com/libp2p/go-libp2p-quic-transport@v0.11.0
go mod vendor
go build
# error: go-libp2p-quic-transport@v0.11.0 is not compatible with quic-go@v0.20.0
# vendor/github.com/libp2p/go-libp2p-quic-transport/stream.go:12:13: undefined: quic.StreamErrorCode

# rollback
rm -rf vendor/
git reset --hard origin/master

# update to go-libp2p-quic-transport@v0.11.0
go mod graph | grep github.com/libp2p/go-libp2p-quic-transport
# v0.10.0
go mod edit -replace github.com/libp2p/go-libp2p-quic-transport=github.com/libp2p/go-libp2p-quic-transport@v0.11.0
go get github.com/libp2p/go-libp2p-quic-transport@v0.11.0
go mod graph | grep "quic-go@v0.19.3$"
# github.com/ipfs/go-ipfs@v0.8.0 github.com/lucas-clemente/quic-go@v0.19.3
# update to quic-go@v0.21.0
go mod edit -replace github.com/lucas-clemente/quic-go=github.com/lucas-clemente/quic-go@v0.21.0
go get github.com/lucas-clemente/quic-go@v0.21.0
go mod graph | grep "quic-go@v0.19.3$"
# github.com/ipfs/go-ipfs@v0.8.0 github.com/lucas-clemente/quic-go@v0.19.3
# so, either go-ipfs still depends on the old quic-go,
# or this is a bug in "go mod graph"

# update to go-libp2p-quic-transport@v0.12.0
go mod edit -replace github.com/libp2p/go-libp2p-quic-transport=github.com/libp2p/go-libp2p-quic-transport@v0.12.0
go get github.com/libp2p/go-libp2p-quic-transport@v0.12.0
go mod graph | grep quic-go
# github.com/libp2p/go-libp2p-quic-transport@v0.12.0 github.com/lucas-clemente/quic-go@v0.23.0
# update to quic-go@v0.23.0
go mod edit -replace github.com/lucas-clemente/quic-go=github.com/lucas-clemente/quic-go@v0.23.0
go get github.com/lucas-clemente/quic-go@v0.23.0
go mod graph | grep "quic-go@v0.19.3$"
# github.com/ipfs/go-ipfs@v0.8.0 github.com/lucas-clemente/quic-go@v0.19.3
# so, either go-ipfs still depends on the old quic-go,
# or this is a bug in "go mod graph"
go mod vendor
# error: golang.org/x/text/encoding: missing go.sum entry for module providing package golang.org/x/text/encoding (imported by golang.org/x/net/html/charset)
```



</details>


i am aware that migration is rarely needed
but at the same time, its silly to not support such a trivial operation
