### PR TITLE
Update run.md

### DIFF
--- a/run.md
+++ b/run.md
@@ -18,7 +18,7 @@ cp -r ~/.ipfs ~/.ipfs.bak
 
 ## Step 1. Downloading the Migration
 
-- If you have Go installed: `go get -u github.com/ipfs/fs-repo-migrations`
+- If you have Go installed: `go install github.com/ipfs/fs-repo-migrations@latest`
 - Otherwise, download a prebuilt binary from [the distributions page](https://dist.ipfs.tech/#fs-repo-migrations)
 
 ## Step 2. Run the Migration


### PR DESCRIPTION
Running the go get command seems like it no longer works and it says to use go install instead.

I changed the line to the new variants. however, this did not seem to expose the binary in my path, so there might be more information that needs updating here.