### PR TITLE
fix(14-to-15): ignore missing CORS headers

### DIFF
--- a/fs-repo-14-to-15/migration/migration.go
+++ b/fs-repo-14-to-15/migration/migration.go
@@ -220,21 +220,15 @@ func convert(in io.Reader, out io.Writer) error {
 
 			if acaos, ok := headers["Access-Control-Allow-Origin"].([]interface{}); ok && len(acaos) == 1 && acaos[0] == "*" {
 				delete(headers, "Access-Control-Allow-Origin")
-			} else {
-				return fmt.Errorf("invalid type for .Gateway.HTTPHeaders[Access-Control-Allow-Origin] got %T expected json array", headers["Access-Control-Allow-Origin"])
 			}
 
 			if acams, ok := headers["Access-Control-Allow-Methods"].([]interface{}); ok && len(acams) == 1 && acams[0] == "GET" {
 				delete(headers, "Access-Control-Allow-Methods")
-			} else {
-				return fmt.Errorf("invalid type for .Gateway.HTTPHeaders[Access-Control-Allow-Methods] got %T expected json array", headers["Access-Control-Allow-Methods"])
 			}
 			if acahs, ok := headers["Access-Control-Allow-Headers"].([]interface{}); ok && len(acahs) == 3 {
 				if acahs[0] == "X-Requested-With" && acahs[1] == "Range" && acahs[2] == "User-Agent" {
 					delete(headers, "Access-Control-Allow-Headers")
 				}
-			} else {
-				return fmt.Errorf("invalid type for .Gateway.HTTPHeaders[Access-Control-Allow-Headers] got %T expected json array", headers["Access-Control-Allow-Headers"])
 			}
 		}
 	}

--- a/sharness/t0030-simple-migration.sh
+++ b/sharness/t0030-simple-migration.sh
@@ -4,7 +4,7 @@ test_description="Simple fs-repo-migrations tests"
 
 . lib/test-lib.sh
 
-latestRepoVersion="14"
+latestRepoVersion="15"
 
 test_expect_success "fs-repo-migrations binary is here" '
 	test -f "$LOCAL_FS_REPO_MIG"


### PR DESCRIPTION
@Jorropo  yhis fixes edge case I've introduced in https://github.com/ipfs/fs-repo-migrations/pull/174 and closes https://github.com/ipfs/fs-repo-migrations/issues/177

(Running migration on config where user manually removed CORS headers, no longer errors, it continues to the next check)

