### PR TITLE
fix(14-to-15): ignore Bootstrap empty

### DIFF
--- a/fs-repo-14-to-15/migration/migration.go
+++ b/fs-repo-14-to-15/migration/migration.go
@@ -162,7 +162,7 @@ func convert(in io.Reader, out io.Writer) error {
 	}
 
 	// Upgrade bootstrapper QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ from /quic to /quic-v1
-	if b, ok := confMap["Bootstrap"]; ok {
+	if b, ok := confMap["Bootstrap"]; ok && b != nil {
 		bootstrap, ok := b.([]interface{})
 		if !ok {
 			return fmt.Errorf("invalid type for .Bootstrap got %T expected json array", b)


### PR DESCRIPTION
if kubo startup with `ipfs bootstrap rm all`, the bootstrap list is empty.

current output
```
applying 14-to-15 repo migration
> Upgrading config to new format
error: invalid type for .Bootstrap got <nil> expected json array
```